### PR TITLE
Add endpoint for table creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+/frontend/frontend.iml

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.mockito:mockito-inline:3.4.0")
 }
 
 tasks.withType<KotlinCompile> {

--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/model/Game.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/model/Game.kt
@@ -1,0 +1,5 @@
+package pl.poznan.put.tsd.planningpoker.backend.model
+
+import java.util.UUID
+
+data class Game(val id: UUID)

--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/TableResource.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/TableResource.kt
@@ -1,0 +1,18 @@
+package pl.poznan.put.tsd.planningpoker.backend.resources
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import pl.poznan.put.tsd.planningpoker.backend.resources.responses.TableCreatedResponse
+import pl.poznan.put.tsd.planningpoker.backend.services.GamesService
+
+@RestController
+class TableResource constructor(private val games: GamesService) {
+    @PostMapping("table")
+    fun createTable(@RequestBody username: String): ResponseEntity<TableCreatedResponse> {
+        val id = games.createGame()
+        return ResponseEntity(TableCreatedResponse(id), HttpStatus.CREATED)
+    }
+}

--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/responses/TableCreatedResponse.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/responses/TableCreatedResponse.kt
@@ -1,0 +1,5 @@
+package pl.poznan.put.tsd.planningpoker.backend.resources.responses
+
+import java.util.UUID
+
+data class TableCreatedResponse(val id: UUID)

--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/services/GamesService.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/services/GamesService.kt
@@ -1,0 +1,21 @@
+package pl.poznan.put.tsd.planningpoker.backend.services
+
+import org.springframework.stereotype.Service
+import pl.poznan.put.tsd.planningpoker.backend.model.Game
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+@Service
+class GamesService {
+    private val games = ConcurrentHashMap<UUID, Game>()
+
+    /**
+     * Creates game
+     * @return game's UUID
+     */
+    fun createGame(): UUID {
+        val id = UUID.randomUUID()
+        games[id] = Game(id)
+        return id
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+server.servlet.context-path=/poker_api/v1

--- a/backend/src/test/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/TableResourceTest.kt
+++ b/backend/src/test/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/TableResourceTest.kt
@@ -1,0 +1,38 @@
+package pl.poznan.put.tsd.planningpoker.backend.resources
+
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class TableResourceTest {
+    @Suppress("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    fun createTable() {
+        val uuidResponse = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+        Mockito.mockStatic(UUID::class.java).use { mocked ->
+            mocked.`when`<UUID>(UUID::randomUUID).thenReturn(uuidResponse)
+
+            mockMvc.perform(
+                post("/table")
+                    .contentType(APPLICATION_JSON)
+                    .content("{\"username\": \"user\"}")
+            ).andExpect(status().isCreated)
+                .andExpect(content().string(containsString("\"id\":\"123e4567-e89b-12d3-a456-426614174000\"")))
+        }
+    }
+}


### PR DESCRIPTION
Added `POST /table` endpoint for creating tables. It takes the creator's username as a request body.

