### PR TITLE
Add dockerfiles and docker-compose files

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+.gradle
+.idea
+build
+.gitignore
+README.md

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM gradle:8.0.2-jdk19-alpine AS build
+
+WORKDIR /app
+
+COPY --chown=gradle:gradle . .
+RUN gradle build
+
+FROM openjdk:19-jdk-slim
+COPY --from=build /app/build/libs/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]
+EXPOSE 8080

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - 8080:8080

--- a/docker-compose-frontend.yml
+++ b/docker-compose-frontend.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  frontend:
+    build: ./frontend
+    ports:
+      - 80:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - 8080:8080
+  frontend:
+    depends_on:
+      - backend
+    build: ./frontend
+    ports:
+      - 80:80

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+.idea
+README.md
+dist
+node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:16 AS build
+
+WORKDIR /app
+
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install
+COPY . ./
+RUN npm run build
+
+FROM nginx:1.23-alpine
+COPY --from=build /app/dist /usr/share/nginx/html


### PR DESCRIPTION
I added Dockerfiles along with dockerignores for both backend and frontend. Also, in root catalgue I added *docker-compose.yml* file which runs both services and *docker-compose* files for local development of 1 of the services: if you want to develop frontend without changing anything in backend, simply run `docker-compose -f docker-compose-backend.yml up` and you dont have to worry about writng right `docker run` command nor starting IntelliJ just to run backend project. Of course, if you want to develop backend only, you can run `docker-compose -f docker-compose-frontend.yml up` respectively.

If you made changes to any of the projects and you want to rebuild docker image, remember to put `--build` after `docker-compose*.yml` command.

Reminder - if we want to make calls from frontend to backend inside *docker-compose*, referencing to *localhost:8080* will not work. Instead, we have to make calls to *backend:8080*, which corresponds to name of the service in *docker-compose.yml* file. Maybe there is a way to create custom environment alongside _dev_ and _prod_ maybe called _docker_ with the url _backend:8080_? If there is, I will update respective Dockerfile to utilize it.