### PR TITLE
Reset board endpoint

### DIFF
--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/TableResource.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/TableResource.kt
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import pl.poznan.put.tsd.planningpoker.backend.resources.requests.CardRequest
+import pl.poznan.put.tsd.planningpoker.backend.resources.requests.GameId
 import pl.poznan.put.tsd.planningpoker.backend.resources.requests.User
 import pl.poznan.put.tsd.planningpoker.backend.resources.responses.TableCreatedResponse
 import pl.poznan.put.tsd.planningpoker.backend.services.GamesService
@@ -41,8 +42,18 @@ class TableResource(private val games: GamesService) {
      */
     @PostMapping("select_card")
     suspend fun selectCard(@RequestBody request: CardRequest): ResponseEntity<Unit> {
-        println(request)
         games.selectCard(request.gameId, request.username, request.card)
+        return ResponseEntity(Unit, HttpStatus.OK)
+    }
+
+    /**
+     * Responses:
+     * 200 - OK
+     * 404 - No such game
+     */
+    @PostMapping("reset_cards")
+    suspend fun resetCards(@RequestBody gameId: GameId): ResponseEntity<Unit> {
+        games.resetCards(gameId.gameId)
         return ResponseEntity(Unit, HttpStatus.OK)
     }
 }

--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/requests/GameId.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/requests/GameId.kt
@@ -1,0 +1,8 @@
+package pl.poznan.put.tsd.planningpoker.backend.resources.requests
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.UUID
+
+data class GameId(
+    @JsonProperty("game_id") val gameId: UUID,
+)

--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/services/GamesService.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/services/GamesService.kt
@@ -58,6 +58,19 @@ class GamesService(
         game.sendBroadcast()
     }
 
+
+    @Throws(GameNotFoundException::class)
+    suspend fun resetCards(id: UUID) {
+        val game = getGameByIdOrThrow(id)
+
+        game.mutex.withLock {
+            game.players.entries.forEach { (key, player) ->
+                game.players[key] = player.copy(selectedCard = Card.NONE)
+            }
+        }
+        game.sendBroadcast()
+    }
+
     @Throws(GameNotFoundException::class)
     private fun getGameByIdOrThrow(id: UUID) =
         _games[id] ?: throw GameNotFoundException("Game with id: $id has been not found")


### PR DESCRIPTION
Sets all users selected card to NONE so new game can start

Sample request
```
POST http://localhost:8080/poker_api/v1/reset_cards
Content-Type: application/json

{
  "game_id": "fa32a33e-950a-47e1-a22c-a8150681fcc1"
}
```
