### PR TITLE
Add next round endpoint

### DIFF
--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/model/Game.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/model/Game.kt
@@ -7,7 +7,8 @@ data class Game(
     val id: UUID,
     val players: MutableMap<String, Player> = mutableMapOf(),
     var areCardsVisible: Boolean = false,
-    var userStories: List<UserStory>
+    var userStories: List<UserStory>,
+    var round: Int = 0,
 ) {
     val mutex: Mutex = Mutex()
 }

--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/TableResource.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/TableResource.kt
@@ -59,6 +59,12 @@ class TableResource(private val gamesService: GamesService) {
         return ResponseEntity(Unit, HttpStatus.OK)
     }
 
+    @PostMapping("next_round")
+    suspend fun nextRound(@RequestBody gameId: GameId): ResponseEntity<Unit> {
+        gamesService.nextRound(gameId.gameId)
+        return ResponseEntity(Unit, HttpStatus.OK)
+    }
+
     @PutMapping("user_stories")
     suspend fun updateUserStories(@RequestBody request: UserStoriesRequest) : ResponseEntity<Unit> {
         gamesService.updateUserStories(request.gameId, request.userStories)

--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/responses/GameResponse.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/resources/responses/GameResponse.kt
@@ -7,11 +7,15 @@ import pl.poznan.put.tsd.planningpoker.backend.resources.responses.UserStoryResp
 data class GameResponse(
     val areCardsVisible: Boolean,
     val players: List<PlayerResponse>,
-    val userStories: List<UserStoryResponse>
+    val userStories: List<UserStoryResponse>,
+    val round: Int,
 ) {
     companion object {
-        fun Game.toResponseModel(): GameResponse =
-            GameResponse(areCardsVisible, players.values.map { it.toResponseModel() },
-                userStories.map { it.toResponseModel() })
+        fun Game.toResponseModel(): GameResponse = GameResponse(
+            areCardsVisible = areCardsVisible,
+            players = players.values.map { it.toResponseModel() },
+            userStories = userStories.map { it.toResponseModel() },
+            round = round
+        )
     }
 }

--- a/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/services/GamesService.kt
+++ b/backend/src/main/kotlin/pl/poznan/put/tsd/planningpoker/backend/services/GamesService.kt
@@ -61,14 +61,27 @@ class GamesService(
     suspend fun resetCards(id: UUID) {
         val game = getGameByIdOrThrow(id)
 
-        game.mutex.withLock {
-            game.players.entries.forEach { (key, player) ->
-                game.players[key] = player.copy(selectedCard = Card.NONE)
-            }
-            game.areCardsVisible = false
-        }
+        game.resetCards()
         game.sendBroadcast()
     }
+
+    @Throws(GameNotFoundException::class)
+    suspend fun nextRound(id: UUID) {
+        getGameByIdOrThrow(id).run {
+            resetCards()
+            round++
+            if (round == userStories.size) userStories = userStories + UserStory("", "", emptyList())
+            sendBroadcast()
+        }
+    }
+
+    private suspend fun Game.resetCards() = mutex.withLock {
+            players.entries.forEach { (key, player) ->
+                players[key] = player.copy(selectedCard = Card.NONE)
+            }
+            areCardsVisible = false
+        }
+
 
     @Throws(GameNotFoundException::class)
     suspend fun updateUserStories(id: UUID, userStories: List<UserStory>) {


### PR DESCRIPTION
Added `next_round` endpoint which controls new game's field - `round`. It allows frontend to decide which user story should be displayed now.